### PR TITLE
Fix for subgoal over-counting

### DIFF
--- a/scripts/output.js
+++ b/scripts/output.js
@@ -234,15 +234,25 @@ function downloadCSV(csvContent, old) {
 }
 
 function downloadURI(uri, name) {
-	var safeName = name;
-	var safeUri = uri.slice(22);
-	console.log("in image", safeUri);
-	var imgObj = {
-		name:safeName+".png",
-		uri: safeUri
-	};
-	console.log("imgobj", imgObj);
-	imgList.push(imgObj);
+	try {
+        //checks to see if the uri or name is null
+        if (uri === null || name === null) throw "The uri or name for your image is null.";
+        var safeName = name;
+        //uri must be converted to string in order to perform slice function to shorten the uri
+        toString(uri);
+        var safeUri = uri.slice(22);
+        console.log("in image", safeUri);
+        //creates the image object using the name and shortened uri
+        var imgObj = {
+            name:safeName+".png",
+            uri: safeUri
+        };
+        console.log("imgobj", imgObj);
+        //pushes the image to the list of images
+        imgList.push(imgObj);
+    } catch (error) {
+        console.log(error);
+    }
 
   }
 

--- a/scripts/prewalkthrough.js
+++ b/scripts/prewalkthrough.js
@@ -305,14 +305,9 @@ function handlePreWalkthroughInfo () {
 			sidebarBody().find("#editPersona").hide();
 			sidebarBody().find("#editScenario").hide();
 			var subgoalId = localStorage.getItem("numSubgoals");
-			if(subgoalId === undefined){
+			if(subgoalId == null){
 				subgoalId = 1;
 				localStorage.setItem("numSubgoals", subgoalId);
-			}
-			else{
-				subgoalId++;
-				localStorage.setItem("numSubgoals", subgoalId);
-				
 			}
 			drawSubgoal(subgoalId);
 		}
@@ -320,12 +315,8 @@ function handlePreWalkthroughInfo () {
 			//They have subgoals
 			//var subName = localStorage.getItem("currSubgoalName");
 			var subgoalId = localStorage.getItem("numSubgoals");
-			if(subgoalId === undefined){
+			if(subgoalId == null){
 				subgoalId = 1;
-				localStorage.setItem("numSubgoals", subgoalId);
-			}
-			else{
-				subgoalId++;
 				localStorage.setItem("numSubgoals", subgoalId);
 			}
             sidebarBody().find("#editTeam").hide();
@@ -350,7 +341,7 @@ function handlePreWalkthroughInfo () {
                 setStatusToTrue("gotSubgoalName");
                 var subName = sidebarBody().find("#subgoalInput").val();
                 localStorage.setItem("currSubgoalName", subName);
-                if(subgoalId === undefined){
+                if(subgoalId == null){
                     subgoalId = 1;
                     localStorage.setItem("numSubgoals", subgoalId);
                 }

--- a/scripts/saveState.js
+++ b/scripts/saveState.js
@@ -54,15 +54,13 @@ function addToSandwich(type, item){
             // add the new subgoal to the sidebar
             if (!foundIt) {
                 sidebarBody().find("#subgoalList").append(sideSubgoal);
-            }
-            
-        }
-		sidebarBody().find("#sideSubgoal" + item.id).unbind( "click" ).click(function(){
-			drawSubgoal(item.id);
-            sideSubgoalExpandy(item.id, 0);
-		});
+        	}
 
-			
+			sidebarBody().find("#sideSubgoal" + item.id).unbind( "click" ).click(function(){
+				drawSubgoal(item.id);
+	            sideSubgoalExpandy(item.id, 0);
+			});		
+		}
 	}
 	else if(!type.localeCompare("idealAction") && item.name){ 	
 		var sideAction = '<div superCoolAttr="' + item.subgoalId + '-' + item.actionId + '" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;text-indent:25px;color:blue;text-decoration:underline;margin:5px;" id="sideAction' + item.subgoalId + '-' + item.actionId + '">Action ' + item.actionId + ': ' + item.name + '</div>';


### PR DESCRIPTION
---
name: Pull request template
about: GenderMag Recorders Assistant project

---

* **What does this implementation fix? Explain your changes.**	
Subgoal numbers now match the actual number of subgoals created. This was done by deleting code in prewalkthrough.js that incremented the subgoal count upon reloading or changing the page.
* **Does this close any open issue? (Give issue id from issue tracker)**
Issue #57 
* **Include any related logs, error, output file etc.**

* **Did you test on Mac and Windows?**
Mac
* **Did you test the full GM process and verify that the code does not contribute any unexpected errors/bugs?**
Yes
* **If possible, provide a screenshot of the functionality.**

* **Any other information?**
It's weird that submission of all new subgoals is handled by prewalkthrough.js, even after the pre-walkthrough is over. I wonder if using onclick events in the HTML would make more sense?