### PR TITLE
Change Exit button label on screenshot overlay

### DIFF
--- a/templates/action.html
+++ b/templates/action.html
@@ -1,6 +1,6 @@
 <html>
 	<body>
-    <button id="exitButton" style="float:right; width:95px; font-size: smaller; height:25px;background-color:#7D1935;color:white;">Save and Exit</button>
+    <button id="exitButton" style="float:right; width:95px; font-size: smaller; height:25px;background-color:#7D1935;color:white;">Exit</button>
         <div id="imageCanvasTemplate"text-align:center;>
 
             <div style="height:25px; background-color:#4A96AD;text-align:center;">


### PR DESCRIPTION
It was 'Save and Exit' but should just be 'Exit' per its functionality and team discussions

---
name: Pull request template
about: GenderMag Recorders Assistant project

---

* **What does this implementation fix? Explain your changes.**	
The Exit button was labelled incorrectly on the screenshot overlay.
* **Does this close any open issue? (Give issue id from issue tracker)**
No.
* **Did you test on Mac and Windows?**
Just Mac.
* **Did you test the full GM process and verify that the code does not contribute any unexpected errors/bugs?**
Yes.
* **Any other information?**
